### PR TITLE
Java 11 compatibility

### DIFF
--- a/src/main/scala/com/banzaicloud/spark/metrics/sink/PrometheusSink.scala
+++ b/src/main/scala/com/banzaicloud/spark/metrics/sink/PrometheusSink.scala
@@ -339,7 +339,7 @@ abstract class PrometheusSink(property: Properties,
       case c if c.getParameterCount == 1 &&
         classOf[Properties].isAssignableFrom(c.getParameterTypes()(0)) =>
         val javaProps = new Properties()
-        javaProps.putAll(props.asJava)
+        javaProps.asScala ++= props
         c.newInstance(javaProps).asInstanceOf[MetricFilter]
     }
 


### PR DESCRIPTION
The project can't be compiled on Java 11 because of a known issue: scala/bug#10418
```
[error] both method putAll in class Properties of type (x$1: java.util.Map[_, _])Unit
[error] and  method putAll in class Hashtable of type (x$1: java.util.Map[_ <: Object, _ <: Object])Unit
[error] match argument types (java.util.Map[String,String])
[error]         javaProps.putAll(props.asJava)
[error]                   ^
[error] one error found
[error] (Compile / compileIncremental) Compilation failed
[error] Total time: 5 s, completed Jun 9, 2021, 5:11:45 PM
```